### PR TITLE
Allow arbitrary JVM versions for testing (not for releasing)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: scala
 
 env:
   global:
+    - PUBLISH_JDK="openjdk6,oraclejdk8"
     # PGP_PASSPHRASE
     - secure: "XLe/gZXrGwJlKCgAUoEUIHwoh8js0IdlIazwUd5KKssZMQkPg4VfC5LLPl8iXCYIRe2JrgmD56b7eseiZF9kMxa1Rsz8fSMY0v3A0qwxRjbsxVQ2NqEvdq+TNOAhjo/OmPnipvTcDdAyq68Ca4nTSBtfBpy5t6X3Z4UIl8CWLdw="
     # SONA_USER

--- a/admin/README.md
+++ b/admin/README.md
@@ -19,8 +19,8 @@ To configure tag driven releases from Travis CI.
      Edit `.travis.yml` as prompted.
   4. Edit `.travis.yml` to use `./admin/build.sh` as the build script,
      and edit that script to use the tasks required for this project.
-  5. Edit `build.sbt` to select which JDK will be used for publishing
-     for which Scala versions.
+  5. Edit `build.sbt` and `travis.yml` to select which JDK will be used
+     for publishing for which Scala versions.
 
 It is important to add comments in .travis.yml to identify the name
 of each environment variable encoded in a `:secure` section.

--- a/admin/build.sh
+++ b/admin/build.sh
@@ -7,7 +7,8 @@ set -e
 # git on travis does not fetch tags, but we have TRAVIS_TAG
 # headTag=$(git describe --exact-match ||:)
 
-if [[ "$TRAVIS_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9-]+)? ]]; then
+# bash string.contains according to http://stackoverflow.com/a/229606/248998
+if [[ "$PUBLISH_JDK" == *"$TRAVIS_JDK_VERSION"* ]] && [[ "$TRAVIS_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9-]+)? ]]; then
   echo "Going to release from tag $TRAVIS_TAG!"
   myVer=$(echo $TRAVIS_TAG | sed -e s/^v//)
   publishVersion='set every version := "'$myVer'"'
@@ -20,6 +21,9 @@ if [[ "$TRAVIS_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9-]+)? ]]; then
   IV=$encrypted_abe708fa1965_iv
 
   openssl aes-256-cbc -K $K -iv $IV -in admin/secring.asc.enc -out admin/secring.asc -d
+else
+  # Allow running on JVMs other than those required to build releases
+  allowAnyJVM="-Dsbt.allowCrossBuildingAnyJVM=true"
 fi
 
-sbt "$publishVersion" clean update +test +publishLocal $extraTarget
+sbt $allowAnyJVM "$publishVersion" clean update +test +publishLocal $extraTarget


### PR DESCRIPTION
If the system property `sbt.allowCrossBuildingAnyJVM` is set, allow
building with any Scala version on any JVM. Scala versions >= 2.12 are
only included on JVM versions >= 1.8 (Scala 2.12 uses bytecode
version 52.0).

By default, if the property is not set, the build enforces jdk 6 for
Scala < 2.12 and jdk 8 for Scala >= 2.12.

```
➜  scala-partest git:(javaVersion) ✗ java6
➜  scala-partest git:(javaVersion) ✗ java -version
java version "1.6.0_65"
Java(TM) SE Runtime Environment (build 1.6.0_65-b14-466.1-11M4716)
Java HotSpot(TM) 64-Bit Server VM (build 20.65-b04-466.1, mixed mode)

➜  scala-partest git:(javaVersion) ✗ sbt crossScalaVersions
[info] Loading global plugins from /Users/luc/.sbt/0.13/plugins
[info] Loading project definition from /Users/luc/scala/scala-partest/project
[info] Compiling 1 Scala source to /Users/luc/scala/scala-partest/project/target/scala-2.10/sbt-0.13/classes...
[info] Set current project to scala-partest (in build file:/Users/luc/scala/scala-partest/)
[info] List(2.11.6)

➜  scala-partest git:(javaVersion) ✗ sbt -Dsbt.allowCrossBuildingAnyJVM=true crossScalaVersions
[info] Loading global plugins from /Users/luc/.sbt/0.13/plugins
[info] Loading project definition from /Users/luc/scala/scala-partest/project
[info] Set current project to scala-partest (in build file:/Users/luc/scala/scala-partest/)
[info] List(2.11.6)

➜  scala-partest git:(javaVersion) ✗ java7
➜  scala-partest git:(javaVersion) ✗ java -version
java version "1.7.0_71"
Java(TM) SE Runtime Environment (build 1.7.0_71-b14)
Java HotSpot(TM) 64-Bit Server VM (build 24.71-b01, mixed mode)

➜  scala-partest git:(javaVersion) ✗ sbt crossScalaVersions
[info] Loading global plugins from /Users/luc/.sbt/0.13/plugins
[info] Loading project definition from /Users/luc/scala/scala-partest/project
[info] Compiling 1 Scala source to /Users/luc/scala/scala-partest/project/target/scala-2.10/sbt-0.13/classes...
java.lang.RuntimeException: don't know what Scala versions to build on 1.7.0_71
  at scala.sys.package$.error(package.scala:27)
  at $f39a9ffafa76043b14ad$$anonfun$$sbtdef$1.publishVersions$1(/Users/luc/scala/scala-partest/build.sbt:36)
  at $f39a9ffafa76043b14ad$$anonfun$$sbtdef$1.apply(/Users/luc/scala/scala-partest/build.sbt:50)
  at $f39a9ffafa76043b14ad$$anonfun$$sbtdef$1.apply(/Users/luc/scala/scala-partest/build.sbt:10)
  at sbt.Init$Value$$anonfun$apply$13.apply(Settings.scala:604)
  at sbt.EvaluateSettings$$anonfun$sbt$EvaluateSettings$$constant$1.apply(INode.scala:163)
  at sbt.EvaluateSettings$$anonfun$sbt$EvaluateSettings$$constant$1.apply(INode.scala:163)
  at sbt.EvaluateSettings$MixedNode.evaluate0(INode.scala:175)
  at sbt.EvaluateSettings$INode.evaluate(INode.scala:135)
  at sbt.EvaluateSettings$$anonfun$sbt$EvaluateSettings$$submitEvaluate$1.apply$mcV$sp(INode.scala:69)
  at sbt.EvaluateSettings.sbt$EvaluateSettings$$run0(INode.scala:78)
  at sbt.EvaluateSettings$$anon$3.run(INode.scala:74)
  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
  at java.lang.Thread.run(Thread.java:745)
[error] don't know what Scala versions to build on 1.7.0_71
[error] Use 'last' for the full log.
Project loading failed: (r)etry, (q)uit, (l)ast, or (i)gnore? q

➜  scala-partest git:(javaVersion) ✗ sbt -Dsbt.allowCrossBuildingAnyJVM=true crossScalaVersions
[info] Loading global plugins from /Users/luc/.sbt/0.13/plugins
[info] Loading project definition from /Users/luc/scala/scala-partest/project
[info] Set current project to scala-partest (in build file:/Users/luc/scala/scala-partest/)
[info] List(2.11.6)

➜  scala-partest git:(javaVersion) ✗ java8
➜  scala-partest git:(javaVersion) ✗ java -version
java version "1.8.0_51"
Java(TM) SE Runtime Environment (build 1.8.0_51-b16)
Java HotSpot(TM) 64-Bit Server VM (build 25.51-b03, mixed mode)

➜  scala-partest git:(javaVersion) ✗ sbt crossScalaVersions
[info] Loading global plugins from /Users/luc/.sbt/0.13/plugins
[info] Loading project definition from /Users/luc/scala/scala-partest/project
[info] Compiling 1 Scala source to /Users/luc/scala/scala-partest/project/target/scala-2.10/sbt-0.13/classes...
[info] Set current project to scala-partest (in build file:/Users/luc/scala/scala-partest/)
[info] List(2.12.0-M1, 2.12.0-M2)

➜  scala-partest git:(javaVersion) ✗ sbt -Dsbt.allowCrossBuildingAnyJVM=true crossScalaVersions
[info] Loading global plugins from /Users/luc/.sbt/0.13/plugins
[info] Loading project definition from /Users/luc/scala/scala-partest/project
[info] Set current project to scala-partest (in build file:/Users/luc/scala/scala-partest/)
[info] List(2.11.6, 2.12.0-M1, 2.12.0-M2)
```
